### PR TITLE
Add a generic Card component

### DIFF
--- a/catalog/index.js
+++ b/catalog/index.js
@@ -29,6 +29,7 @@ const pages = [
       },
       require('../src/components/Button/catalog').default,
       require('../src/components/Grid/catalog').default,
+      require('../src/components/Card/catalog').default,
       require('../src/components/Number/catalog').default,
       require('../src/components/ProgressBar/catalog').default,
       require('../src/components/PieChart/catalog').default,

--- a/package.json
+++ b/package.json
@@ -28,10 +28,7 @@
   },
   "dependencies": {
     "polished": "^1.8.0",
-    "react-click-outside": "^3.0.0",
     "react-modal": "^3.1.10",
-    "react-transition-group": "^2.2.1",
-    "recompose": "^0.25.1",
     "styled-system": "^2.1.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "polished": "^1.8.0",
     "react-click-outside": "^3.0.0",
     "react-modal": "^3.1.10",
-    "react-simple-popover": "^0.2.4",
     "react-transition-group": "^2.2.1",
     "recompose": "^0.25.1",
     "styled-system": "^2.1.1"
@@ -47,7 +46,7 @@
     "babel-preset-latest": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "bit-bin": "^0.12.9",
-    "catalog": "^3.1.2",
+    "catalog": "^3.4.0",
     "eslint": "^4.2.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
     "polished": "^1.8.0",
     "react-click-outside": "^3.0.0",
     "react-modal": "^3.1.10",
+    "react-simple-popover": "^0.2.4",
     "react-transition-group": "^2.2.1",
     "recompose": "^0.25.1",
-    "styled-system": "^1.1.1"
+    "styled-system": "^2.1.1"
   },
   "peerDependencies": {
     "glamor": "^2.20.40",

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -4,3 +4,26 @@
   <Text>Anything goes.</Text>
 </Card>
 ```
+
+# With actions
+```react|span-3
+<Card
+actions={[
+  {
+    name: 'Setup',
+    action: () => console.log('Clicked Action 1')
+  },
+  {
+    name: 'Users',
+    action: () => console.log('Clicked Action 1')
+  },
+  {
+    name: 'Delete',
+    action: () => console.log('Clicked Action 2'),
+    type: 'destructive',
+  }
+]}>
+  <Heading is='h3'>Heading</Heading>
+  <Text>Anything goes.</Text>
+</Card>
+```

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -1,0 +1,6 @@
+```react|span-3
+<Card>
+  <Heading is='h3'>Heading</Heading>
+  <Text>Anything goes.</Text>
+</Card>
+```

--- a/src/components/Card/catalog.js
+++ b/src/components/Card/catalog.js
@@ -1,0 +1,10 @@
+import Card from '.'
+import Heading from '../Heading'
+import Text from '../Text'
+
+export default {
+  title: 'Card',
+  path: '/components/card',
+  imports: { Card, Heading, Text },
+  component: require('./README.md'),
+}

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -1,0 +1,8 @@
+import { StyledCard } from './styled'
+
+const Card = props =>
+  <StyledCard p={3} {...props}>
+    {props.children}
+  </StyledCard>
+
+export default Card

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -18,32 +18,43 @@ class Actions extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      toggleActions: false
+      showActions: false
     }
   }
 
   render () {
     const { actions } = this.props
-    const { toggleActions } = this.state
+    const { showActions } = this.state
+
     return (
       <span>
-        <StyledMoreButton onClick={() => this.setState({toggleActions: true})}>
+        <StyledMoreButton
+          innerRef={ref => this.button = ref}
+          onClick={() => this.setState({showActions: !showActions})}
+        >
           <MoreIcon />
           <span>Open actions</span>
         </StyledMoreButton>
         <Dropdown
-          toggle={toggleActions}
-          close={() => this.setState({toggleActions: false})}
+          target={this.button}
+          show={showActions}
+          close={() => this.setState({showActions: false})}
           actions={actions} />
       </span>
     )
   }
 }
 
-const Card = props =>
-  <StyledCard p={3} {...props}>
-    {props.actions && <Actions {...props} />}
-    {props.children}
-  </StyledCard>
+class Card extends Component {
+  render () {
+    const { actions, children, ...props } = this.props
+    return (
+      <StyledCard {...props} p={3}>
+        {actions && <Actions {...this.props} />}
+        {children}
+      </StyledCard>
+    )
+  }
+}
 
 export default Card

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -14,17 +14,8 @@ const MoreIcon = () =>
   </StyledMoreIcon>
 
 class Actions extends Component {
-
-  constructor(props) {
-    super(props)
-    this.state = {
-      showActions: false
-    }
-  }
-
   render () {
     const { actions } = this.props
-    const { showActions } = this.state
 
     return (
       <div style={{
@@ -36,13 +27,13 @@ class Actions extends Component {
         padding: 0,
       }}>
       <Dropdown
+        right
         renderTrigger={props => (
           <StyledMoreButton type="button" {...props}>
             <MoreIcon />
             <span>Open actions</span>
           </StyledMoreButton>
         )}
-        open={showActions}
         actions={actions} />
       </div>
     )

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -1,7 +1,48 @@
-import { StyledCard } from './styled'
+import React, { Component } from 'react'
+import Dropdown from '../Dropdown'
+
+import {
+  StyledCard,
+  StyledMoreButton,
+  StyledMoreIcon,
+} from './styled'
+
+
+const MoreIcon = () =>
+  <StyledMoreIcon viewBox="0 0 24 24">
+    <path d="M12,14 C10.8954305,14 10,13.1045695 10,12 C10,10.8954305 10.8954305,10 12,10 C13.1045695,10 14,10.8954305 14,12 C14,13.1045695 13.1045695,14 12,14 Z M19,14 C17.8954305,14 17,13.1045695 17,12 C17,10.8954305 17.8954305,10 19,10 C20.1045695,10 21,10.8954305 21,12 C21,13.1045695 20.1045695,14 19,14 Z M5,14 C3.8954305,14 3,13.1045695 3,12 C3,10.8954305 3.8954305,10 5,10 C6.1045695,10 7,10.8954305 7,12 C7,13.1045695 6.1045695,14 5,14 Z"/>
+  </StyledMoreIcon>
+
+class Actions extends Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      toggleActions: false
+    }
+  }
+
+  render () {
+    const { actions } = this.props
+    const { toggleActions } = this.state
+    return (
+      <span>
+        <StyledMoreButton onClick={() => this.setState({toggleActions: true})}>
+          <MoreIcon />
+          <span>Open actions</span>
+        </StyledMoreButton>
+        <Dropdown
+          toggle={toggleActions}
+          close={() => this.setState({toggleActions: false})}
+          actions={actions} />
+      </span>
+    )
+  }
+}
 
 const Card = props =>
   <StyledCard p={3} {...props}>
+    {props.actions && <Actions {...props} />}
     {props.children}
   </StyledCard>
 

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -27,20 +27,24 @@ class Actions extends Component {
     const { showActions } = this.state
 
     return (
-      <span>
-        <StyledMoreButton
-          innerRef={ref => this.button = ref}
-          onClick={() => this.setState({showActions: !showActions})}
-        >
-          <MoreIcon />
-          <span>Open actions</span>
-        </StyledMoreButton>
-        <Dropdown
-          target={this.button}
-          show={showActions}
-          close={() => this.setState({showActions: false})}
-          actions={actions} />
-      </span>
+      <div style={{
+        position: 'absolute',
+        top: '24px',
+        right: '24px',
+        width: '24px',
+        height: '24px',
+        padding: 0,
+      }}>
+      <Dropdown
+        renderTrigger={props => (
+          <StyledMoreButton type="button" {...props}>
+            <MoreIcon />
+            <span>Open actions</span>
+          </StyledMoreButton>
+        )}
+        open={showActions}
+        actions={actions} />
+      </div>
     )
   }
 }

--- a/src/components/Card/styled.js
+++ b/src/components/Card/styled.js
@@ -15,9 +15,6 @@ export const StyledCard = glamorous(Box)({
 })
 
 export const StyledMoreButton = glamorous.button({
-  position: 'absolute',
-  top: '24px',
-  right: '24px',
   height: '24px',
   width: '24px',
   border: 'none',

--- a/src/components/Card/styled.js
+++ b/src/components/Card/styled.js
@@ -1,0 +1,15 @@
+import glamorous from 'glamorous'
+import { Box } from '../Grid'
+import theme from '../../styles/theme'
+
+export const StyledCard = glamorous(Box)({
+  width: '100%',
+  alignItems: 'center',
+  backgroundColor: theme.colors.white,
+  borderRadius: theme.radius*2,
+  transition: 'box-shadow .2s',
+  position: 'relative',
+  '&:hover': {
+    boxShadow: '0 2px 6px 0 rgba(0,0,0,.1)',
+  },
+})

--- a/src/components/Card/styled.js
+++ b/src/components/Card/styled.js
@@ -13,3 +13,30 @@ export const StyledCard = glamorous(Box)({
     boxShadow: '0 2px 6px 0 rgba(0,0,0,.1)',
   },
 })
+
+export const StyledMoreButton = glamorous.button({
+  position: 'absolute',
+  top: '24px',
+  right: '24px',
+  height: '24px',
+  width: '24px',
+  border: 'none',
+  backgroundColor: 'transparent',
+  padding: 0,
+  fill: theme.colors.muted,
+  cursor: 'pointer',
+  '& span': {
+    display: 'none',
+  },
+  '&:hover': {
+    fill: theme.colors.primary,
+  },
+  '&:active,&:focus': {
+    outline: 'none',
+  }
+})
+
+export const StyledMoreIcon = glamorous.svg({
+  height: '24px',
+  width: '24px',
+})

--- a/src/components/CompletionCard/README.md
+++ b/src/components/CompletionCard/README.md
@@ -2,7 +2,14 @@
 ```react
 <CompletionCard
   name="Website"
-  completion="90.2" />
+  completion={{
+    value: 90.2,
+    description: 'completion rate'
+  }}
+  responses={{
+    value: 2192,
+    description: 'responses'
+  }} />
 ```
 
 ## In grid
@@ -11,17 +18,38 @@
   <Flex w={[1, 1/2, 1/3]} p={2}>
     <CompletionCard
       name="Website"
-      completion="99.6" />
+      completion={{
+        value: 99.6,
+        description: 'completion rate'
+      }}
+      responses={{
+        value: 9999,
+        description: 'responses'
+      }} />
   </Flex>
   <Flex w={[1, 1/2, 1/3]} p={2}>
     <CompletionCard
-      name="iOS"
-      completion="78.5" />
+      name="App"
+      completion={{
+        value: 78.5,
+        description: 'completion rate'
+      }}
+      responses={{
+        value: 9999,
+        description: 'responses'
+      }} />
   </Flex>
   <Flex w={[1, 1/2, 1/3]} p={2}>
     <CompletionCard
       name="Android"
-      completion="56.2" />
+      completion={{
+        value: 56.2,
+        description: 'completion rate'
+      }}
+      responses={{
+        value: 9999,
+        description: 'responses'
+      }} />
   </Flex>
 </Flex>
 ```

--- a/src/components/CompletionCard/index.js
+++ b/src/components/CompletionCard/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import T from 'prop-types'
 import {
-  StyledBox,
+  StyledCard,
   StyledHeading,
   StyledText,
 } from './styled'
@@ -14,14 +14,15 @@ class CompletionCard extends Component {
     const {
       name,
       completion,
-      description,
+      responses,
     } = this.props
     return (
-      <StyledBox p={3} completion={completion}>
-        <StyledHeading is='h2' mb={3}>{name}</StyledHeading>
-        <StyledText small muted>{description}</StyledText>
-        <Percentage size="large" value={completion} />
-      </StyledBox>
+      <StyledCard completion={completion.value}>
+        <StyledHeading is='h2' mb={2}>{name}</StyledHeading>
+        <Percentage size="display" value={completion.value} />
+        <StyledText small>{completion.description}</StyledText>
+        <StyledText small mt={2}><strong>{responses.value}</strong> {responses.description}</StyledText>
+      </StyledCard>
     )
   }
 }
@@ -29,8 +30,8 @@ class CompletionCard extends Component {
 if (process.env.NODE_ENV !== 'production') {
   CompletionCard.propTypes = {
     name: T.string.isRequired,
-    completion: T.number,
-    description: T.string,
+    completion: T.object,
+    responses: T.object,
   }
 }
 

--- a/src/components/CompletionCard/styled.js
+++ b/src/components/CompletionCard/styled.js
@@ -4,11 +4,11 @@ import { completionGradient, ellipsis } from '../../styles/mixins'
 import { getPercentage } from '../../utils/calculations'
 import { fontSize } from '../../styles/mixins'
 import { colors } from '../../styles/colors'
-import { Box } from '../Grid'
+import Card from '../Card'
 import Heading from '../Heading'
 import Text from '../Text'
 
-export const StyledBox = glamorous(Box)({
+export const StyledCard = glamorous(Card)({
   backgroundColor: colors.primaryShaded,
   alignItems: 'center',
   borderRadius: theme.radius*2,
@@ -35,4 +35,5 @@ export const StyledHeading = glamorous(Heading)({
 
 export const StyledText = glamorous(Text)({
   display: 'block',
+  marginBottom: '0',
 })

--- a/src/components/Dropdown/README.md
+++ b/src/components/Dropdown/README.md
@@ -1,24 +1,54 @@
 ```react
-state: {isOpened: true}
+state: {toggle: true}
 ---
 <div>
   
-  <button onClick={() => setState({isOpened: !state.isOpened})}>
+  <button onClick={() => setState({toggle: !state.toggle})}>
     Toggle dropdown
   </button>
 
-  <Dropdown show={state.isOpened}>
-    <Option onClick={() => console.log('Clicked Option 1')}>Option 1</Option>
-    <Option onClick={() => console.log('Clicked Option 2')}>Option 2</Option>
-    <Option onClick={() => console.log('Clicked Option 3')}>Option 3</Option>
-    <Option disabled onClick={() => console.log('Clicked Option 4')}>Option 4</Option>
-    <Separator />
-    <Option onClick={() => console.log('Clicked Option 5')}>Option 5</Option>
-    <Option onClick={() => console.log('Clicked Option 6')}>Option 6</Option>
-    <Option onClick={() => console.log('Clicked Option 7')}>Option 7</Option>
-    <Separator />
-    <Option destructive onClick={() => console.log('Clicked Delete')}>Delete</Option>
-  </Dropdown>
+  <Dropdown
+    toggle={state.toggle}
+    close={() => setState({toggle: false})}
+    actions={[
+      {
+        name: 'Option 1',
+        type: '',
+        action: () => console.log('Clicked Option 1'),
+      },
+      {
+        name: 'Option 2',
+        type: '',
+        action: () => console.log('Clicked Option 2'),
+      },
+      {
+        name: 'Option 3',
+        type: '',
+        action: () => console.log('Clicked Option 3'),
+      },
+      {
+        name: 'Option 4',
+        type: '',
+        action: () => console.log('Clicked Option 4'),
+      },
+      {
+        type: 'separator',
+      },
+      {
+        name: 'Heading',
+        type: 'heading',
+      },
+      {
+        name: 'Option 5',
+        type: '',
+        action: () => console.log('Clicked Option 5'),
+      },
+      {
+        name: 'Option 6',
+        type: 'destructive',
+        action: () => console.log('Clicked Option 6'),
+      }
+    ]} />
   
 </div>
 ```

--- a/src/components/Dropdown/README.md
+++ b/src/components/Dropdown/README.md
@@ -8,8 +8,9 @@ state: {toggle: true}
   </button>
 
   <Dropdown
-    toggle={state.toggle}
+    show={state.toggle}
     close={() => setState({toggle: false})}
+    target={this}
     actions={[
       {
         name: 'Option 1',

--- a/src/components/Dropdown/README.md
+++ b/src/components/Dropdown/README.md
@@ -2,15 +2,10 @@
 state: {toggle: true}
 ---
 <div>
-  
-  <button onClick={() => setState({toggle: !state.toggle})}>
-    Toggle dropdown
-  </button>
-
   <Dropdown
-    show={state.toggle}
-    close={() => setState({toggle: false})}
-    target={this}
+    renderTrigger={props => {
+      return <button {...props}>Toggle it</button>
+    }}
     actions={[
       {
         name: 'Option 1',
@@ -45,9 +40,9 @@ state: {toggle: true}
         action: () => console.log('Clicked Option 5'),
       },
       {
-        name: 'Option 6',
+        name: 'Delete',
         type: 'destructive',
-        action: () => console.log('Clicked Option 6'),
+        action: () => console.log('Delete'),
       }
     ]} />
   

--- a/src/components/Dropdown/catalog.js
+++ b/src/components/Dropdown/catalog.js
@@ -1,8 +1,8 @@
-import Dropdown, {Option, Separator} from '.'
+import Dropdown from '.'
 
 export default {
   title: 'Dropdown',
   path: '/components/dropdown',
-  imports: { Dropdown, Option, Separator },
+  imports: { Dropdown },
   component: require('./README.md'),
 }

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import T from 'prop-types'
-import Popover from 'react-simple-popover'
 
 import {
   StyledWrapper,

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -11,17 +11,15 @@ import {
 
 class Dropdown extends Component {
   static defaultProps = {
-    renderTrigger: (props) => <button type="button" {...props}>Toggle</button>
+    right: false,
+    renderTrigger: (props) => (
+      <button type="button" {...props}>Toggle</button>
+    ),
   }
 
-  constructor (props) {
-    super(props)
-    this.state = {
-      open: 'open' in props ? props.open : false,
-    }
-    if (this.state.open) {
-      document.addEventListener('click', this.closeMenu)
-    }
+  state = {
+    open: false,
+    height: 0,
   }
 
   closeMenu = (event) => {
@@ -35,7 +33,11 @@ class Dropdown extends Component {
   toggle = (event) => {
     event.preventDefault()
     const open = !this.state.open
-    this.setState({ open }, () => {
+    let height = this.state.height
+    if (open && !height) {
+      height = this.wrapper.offsetHeight
+    }
+    this.setState({ open, height }, () => {
       if (open) {
         document.addEventListener('click', this.closeMenu)
       } else {
@@ -46,15 +48,21 @@ class Dropdown extends Component {
 
   render () {
     const {
+      right,
       actions,
       renderTrigger,
     } = this.props
-    const { open } = this.state
+    const { open, height } = this.state
 
     return (
-      <StyledWrapper>
+      <StyledWrapper innerRef={ref => this.wrapper = ref}>
         { renderTrigger({ onClick: this.toggle }) }
-        <StyledDropdown open={open} innerRef={ref => this.dd = ref}>
+        <StyledDropdown
+          open={open}
+          right={right}
+          innerRef={ref => this.dd = ref}
+          css={{ top: height }}
+        >
           {actions.map((action, key) => {
             const props = { key: `action-${key}` }
             switch(action.type) {

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -7,65 +7,76 @@ import {
   StyledAction,
   StyledHeading,
   StyledSeparator,
+  StyledDropdown,
 } from './styled'
-
-const Actions = ({ actions }) => {
-  return (
-    actions.map((action, key) =>
-      {switch(action.type) {
-        case 'separator':
-          return <StyledSeparator key={action.key} />
-        case 'heading':
-          return <StyledHeading key={action.key}>{action.name}</StyledHeading>
-        default:
-          return <StyledAction key={action.key} destructive={action.type}>{action.name}</StyledAction>
-      }}
-    )
-  )
-}
-
-const overlayClassName = 'overlay'
 
 class Dropdown extends Component {
   static defaultProps = {
-    title: 'Please select…',
+    renderTrigger: (props) => <button type="button" {...props}>Toggle</button>
+  }
+
+  constructor (props) {
+    super(props)
+    this.state = {
+      open: 'open' in props ? props.open : false,
+    }
+    if (this.state.open) {
+      document.addEventListener('click', this.closeMenu)
+    }
+  }
+
+  closeMenu = (event) => {
+    if (this.dd && !this.dd.contains(event.target)) {
+      this.setState({ open: false }, () => {
+        document.removeEventListener('click', this.closeMenu)
+      })
+    }
+  }
+
+  toggle = (event) => {
+    event.preventDefault()
+    const open = !this.state.open
+    this.setState({ open }, () => {
+      if (open) {
+        document.addEventListener('click', this.closeMenu)
+      } else {
+        document.removeEventListener('click', this.closeMenu)
+      }
+    })
   }
 
   render () {
     const {
-      title,
-      close,
-      show,
       actions,
-      target,
-      container,
+      renderTrigger,
     } = this.props
+    const { open } = this.state
 
     return (
-      <div ref={ref => this.container = ref}>
-        <StyledWrapper
-          show={show}
-          onHide={close}
-          hideWithOutsideClick={true}
-          container={container || this.container}
-          target={target || this.container}
-          role='dialog'>
-          <Actions actions={actions} />
-        </StyledWrapper>
-      </div>
+      <StyledWrapper>
+        { renderTrigger({ onClick: this.toggle }) }
+        <StyledDropdown open={open} innerRef={ref => this.dd = ref}>
+          {actions.map((action, key) => {
+            const props = { key: `action-${key}` }
+            switch(action.type) {
+              case 'separator':
+                return <StyledSeparator {...props} />
+              case 'heading':
+                return <StyledHeading {...props}>{action.name}</StyledHeading>
+              default:
+                return <StyledAction {...props} destructive={action.type === 'destructive'}>{action.name}</StyledAction>
+            }
+          })}
+        </StyledDropdown>
+      </StyledWrapper>
     )
-
   }
 }
 
 if (process.env.NODE_ENV !== 'production') {
   Dropdown.propTypes = {
-    title: T.string,
-    close: T.func,
-    show: T.bool.isRequired,
-    actions: T.array.isRequired,
-    target: T.node,
-    container: T.node,
+    open: T.bool,
+    actions: T.array,
   }
 }
 

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react'
 import T from 'prop-types'
+import Popover from 'react-simple-popover'
 
 import {
-  overlayStyles,
-  dropdownStyles,
   StyledWrapper,
   StyledAction,
   StyledHeading,
@@ -36,21 +35,24 @@ class Dropdown extends Component {
     const {
       title,
       close,
-      toggle,
+      show,
       actions,
+      target,
+      container,
     } = this.props
 
     return (
-      <StyledWrapper
-        isOpen={toggle}
-        onRequestClose={close}
-        contentLabel={title}
-        ariaHideApp={false}
-        className='dropdown'
-        overlayClassName={`${overlayStyles} ${overlayClassName}`}
-        role='dialog'>
-        <Actions actions={actions} />
-      </StyledWrapper>
+      <div ref={ref => this.container = ref}>
+        <StyledWrapper
+          show={show}
+          onHide={close}
+          hideWithOutsideClick={true}
+          container={container || this.container}
+          target={target || this.container}
+          role='dialog'>
+          <Actions actions={actions} />
+        </StyledWrapper>
+      </div>
     )
 
   }
@@ -60,8 +62,10 @@ if (process.env.NODE_ENV !== 'production') {
   Dropdown.propTypes = {
     title: T.string,
     close: T.func,
-    toggle: T.bool.isRequired,
+    show: T.bool.isRequired,
     actions: T.array.isRequired,
+    target: T.node,
+    container: T.node,
   }
 }
 

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -1,67 +1,68 @@
-import React, {Component} from 'react'
-import enhanceWithClickOutside from 'react-click-outside'
-import {Transition} from 'react-transition-group'
+import React, { Component } from 'react'
 import T from 'prop-types'
 
 import {
-  StyledList,
-  StyledOption,
-  StyledSeparator
+  overlayStyles,
+  dropdownStyles,
+  StyledWrapper,
+  StyledAction,
+  StyledHeading,
+  StyledSeparator,
 } from './styled'
 
-export const Option = props =>
-  <StyledOption role="button" tabindex="0" {...props}>{props.children}</StyledOption>
+const Actions = ({ actions }) => {
+  return (
+    actions.map((action, key) =>
+      {switch(action.type) {
+        case 'separator':
+          return <StyledSeparator key={action.key} />
+        case 'heading':
+          return <StyledHeading key={action.key}>{action.name}</StyledHeading>
+        default:
+          return <StyledAction key={action.key} destructive={action.type}>{action.name}</StyledAction>
+      }}
+    )
+  )
+}
 
-export const Separator = props =>
-  <StyledSeparator />
-
-const Fade = ({ children, in: inProp }) => (
-  <Transition
-    in={inProp}
-    timeout={{enter: 0, exit: 300}}
-    mountOnEnter={true}
-    unmountOnExit={true}>
-    {(state) => (
-      <StyledList status={state}>
-        {children}
-      </StyledList>
-    )}
-  </Transition>
-)
+const overlayClassName = 'overlay'
 
 class Dropdown extends Component {
-
-  state = {
-    isOpened: this.props.show
-  }
-
-  handleClickOutside = e => {
-    e.preventDefault()
-    e.stopPropagation()
-    this.toggle()
-  }
-
-  toggle() {
-    this.setState({ isOpened: !this.state.isOpened })
+  static defaultProps = {
+    title: 'Please select…',
   }
 
   render () {
-    const {show, children} = this.props
-    const {isOpened} = this.state
+    const {
+      title,
+      close,
+      toggle,
+      actions,
+    } = this.props
+
     return (
-      <Fade
-        wrappedRef={instance => { this.toggle = instance.toggle }}
-        in={isOpened}>
-        {children}
-      </Fade>
+      <StyledWrapper
+        isOpen={toggle}
+        onRequestClose={close}
+        contentLabel={title}
+        ariaHideApp={false}
+        className='dropdown'
+        overlayClassName={`${overlayStyles} ${overlayClassName}`}
+        role='dialog'>
+        <Actions actions={actions} />
+      </StyledWrapper>
     )
+
   }
 }
 
 if (process.env.NODE_ENV !== 'production') {
   Dropdown.propTypes = {
-    show: T.bool.isRequired,
+    title: T.string,
+    close: T.func,
+    toggle: T.bool.isRequired,
+    actions: T.array.isRequired,
   }
 }
 
-export default enhanceWithClickOutside(Dropdown)
+export default Dropdown

--- a/src/components/Dropdown/styled.js
+++ b/src/components/Dropdown/styled.js
@@ -1,92 +1,78 @@
 import glamorous from 'glamorous'
-import {rgba} from 'polished'
-import * as spacing from '../../styles/spacing'
-import {font, fontSize} from '../../styles/mixins'
+import {css} from 'glamor'
 import theme from '../../styles/theme'
-import {colors} from '../../styles/colors'
+import {font, fontSize} from '../../styles/mixins'
+import styleIf from '../../utils/styleIf'
+import {rgba} from 'polished'
 import {Box} from '../Grid'
+import ReactModal from 'react-modal'
 
-export const StyledList = glamorous.ul({
-  backgroundColor: colors.white,
-  borderRadius: theme.radius*2,
-  padding: spacing.unit,
-  position: 'absolute',
-  boxShadow: '0 0 0 2px rgba(0,0,0,0.1)',
+css.global('.dropdown.ReactModal__Content', {
+  opacity: 0,
+})
+
+css.global('.dropdown.ReactModal__Content--after-open', {
+  opacity: 1,
+  transition: 'opacity 150ms',
+})
+
+css.global('.dropdown.ReactModal__Content--before-close', {
+  opacity: 0,
+})
+
+export const overlayStyles = css({
+  backgroundColor: 'transparent',
+  position: 'fixed',
+  top: 0, left: 0, right: 0, bottom: 0,
+})
+
+export const StyledWrapper = glamorous(ReactModal)({
   maxWidth: '300px',
   minWidth: '160px',
-  transformOrigin: 'top center',
-  opacity: 0,
-  transform: 'translate3D(0, -10px, 0)',
-  WebkitBackfaceVisibility: 'hidden',
-  transformStyle: 'preserve-3d',
-  transition: 'opacity .3s',
-  visibility: 'hidden',
-}, props => {
-  // if (props.status === 'entering') {
-  //   return {
-  //     opacity: 0,
-  //   }
-  // }
-  if (props.status === 'entered') {
-    return {
-      opacity: 1,
-      transform: 'translate3D(0,0,0)',
-      transition: 'opacity .3s, transform .3s',
-      visibility: 'visible',
-    }
-  }
-  if (props.status === 'exiting') {
-    return {
-      opacity: 0,
-      transform: 'translate3D(0,0,0)',
-      visibility: 'visible',
-      transition: 'opacity .2s',
-    }
-  }
-  if (props.status === 'exited') {
-    return {
-      visibility: 'hidden',
-    }
+  backgroundColor: theme.colors.white,
+  borderRadius: theme.radius*2,
+  padding: theme.space[1],
+  boxShadow: '0 0 0 2px rgba(0,0,0,0.1)',
+  position: 'relative',
+  top: '50%',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  '&:focus': {
+    outline: 'none',
   }
 })
 
-export const StyledOption = glamorous(Box)({
+const styledDestructive = styleIf('destructive', {
+  color: theme.colors.trouble,
+})
+
+export const StyledAction = glamorous(Box)({
   ...font('normal'),
   backgroundColor: 'transparent',
-  padding: spacing.unit,
-  paddingLeft: spacing.unit*2,
-  paddingRight: spacing.unit*2,
+  padding: theme.space[1],
+  paddingLeft: theme.space[2],
+  paddingRight: theme.space[2],
   borderRadius: theme.radius,
-  color: colors.primary,
+  color: theme.colors.primary,
   cursor: 'pointer',
   '&:hover,&:focus,&:active': {
-    backgroundColor: rgba(colors.primary, 0.1),
+    backgroundColor: rgba(theme.colors.primary, 0.1),
   },
-}, props => {
-  if (props.destructive) {
-    return {
-      color: colors.trouble,
-      '&:hover,&:focus,&:active': {
-        backgroundColor: rgba(colors.trouble, 0.1),
-      },
-    }
-  }
-  if (props.disabled) {
-    return {
-      color: rgba(colors.text,0.5),
-      cursor: 'not-allowed',
-      '&:hover,&:focus,&:active': {
-        backgroundColor: 'transparent',
-      },
-    }
-  }
+},
+styledDestructive
+)
+
+export const StyledHeading = glamorous(Box)({
+  ...font('bold'),
+  padding: theme.space[1],
+  paddingLeft: theme.space[2],
+  paddingRight: theme.space[2],
 })
 
-export const StyledSeparator = glamorous('span')({
-  backgroundColor: 'rgba(0,0,0,0.1)',
+export const StyledSeparator = glamorous(Box)({
+  backgroundColor: '#D5D7DA',
+  margin: `${theme.space[1]}px 0`,
   display: 'block',
-  width: '100%',
   height: '1px',
-  marginTop: spacing.unit,
-  marginBottom: spacing.unit,
+  width: '100%',
 })

--- a/src/components/Dropdown/styled.js
+++ b/src/components/Dropdown/styled.js
@@ -5,19 +5,32 @@ import {font, fontSize} from '../../styles/mixins'
 import styleIf from '../../utils/styleIf'
 import {rgba} from 'polished'
 import {Box} from '../Grid'
-import Popover from 'react-simple-popover'
 
-export const StyledWrapper = glamorous(Popover)({
+export const StyledWrapper = glamorous('span')({
+  position: 'relative',
+})
+
+export const StyledDropdown = glamorous('dialog')({
   maxWidth: '300px',
   minWidth: '160px',
   backgroundColor: theme.colors.white,
   borderRadius: theme.radius*2,
+  borderWidth: 0,
   padding: theme.space[1],
   boxShadow: '0 0 0 2px rgba(0,0,0,0.1)',
-  transform: 'translateX(-50%)',
+  left: 'auto',
+  right: 'auto',
   '&:focus': {
     outline: 'none',
-  }
+  },
+  animation: `${css.keyframes({
+    '0%': { transform: 'translateY(-5%)', opacity: 0 },
+    '20%': { transform: 'translateY(-5%)', opacity: .2},
+    '40%': { transform: 'translateY(-4%)', opacity: .4 },
+    '50%': { transform: 'translateY(-3%)', opacity: .8 },
+    '70%': { transform: 'translateY(-1%)', opacity: 1 },
+    '100%': { transform: 'translateY(0%)' },
+  })} 150ms linear`,
 })
 
 const styledDestructive = styleIf('destructive', {

--- a/src/components/Dropdown/styled.js
+++ b/src/components/Dropdown/styled.js
@@ -1,9 +1,12 @@
 import glamorous from 'glamorous'
 import {css} from 'glamor'
+import {rgba} from 'polished'
+import { width, space } from 'styled-system'
+
 import theme from '../../styles/theme'
 import {font, fontSize} from '../../styles/mixins'
 import styleIf from '../../utils/styleIf'
-import {rgba} from 'polished'
+
 import {Box} from '../Grid'
 
 export const StyledWrapper = glamorous('span')({
@@ -18,20 +21,30 @@ export const StyledDropdown = glamorous('dialog')({
   borderWidth: 0,
   padding: theme.space[1],
   boxShadow: '0 0 0 2px rgba(0,0,0,0.1)',
-  left: 'auto',
-  right: 'auto',
+  left: null,
+  right: null,
   '&:focus': {
     outline: 'none',
   },
   animation: `${css.keyframes({
-    '0%': { transform: 'translateY(-5%)', opacity: 0 },
-    '20%': { transform: 'translateY(-5%)', opacity: .2},
-    '40%': { transform: 'translateY(-4%)', opacity: .4 },
-    '50%': { transform: 'translateY(-3%)', opacity: .8 },
-    '70%': { transform: 'translateY(-1%)', opacity: 1 },
-    '100%': { transform: 'translateY(0%)' },
+    '0%': { opacity: 0 },
+    '20%': { opacity: .2},
+    '40%': { opacity: .4 },
+    '50%': { opacity: .8 },
+    '100%': { opacity: 1 },
   })} 150ms linear`,
-})
+},
+  (props) => {
+    if (props.right) {
+      return {
+        transform: 'translateX(-100%)',
+        left: '100%',
+      }
+    }
+  },
+  width,
+  space
+)
 
 const styledDestructive = styleIf('destructive', {
   color: theme.colors.trouble,

--- a/src/components/Dropdown/styled.js
+++ b/src/components/Dropdown/styled.js
@@ -5,37 +5,15 @@ import {font, fontSize} from '../../styles/mixins'
 import styleIf from '../../utils/styleIf'
 import {rgba} from 'polished'
 import {Box} from '../Grid'
-import ReactModal from 'react-modal'
+import Popover from 'react-simple-popover'
 
-css.global('.dropdown.ReactModal__Content', {
-  opacity: 0,
-})
-
-css.global('.dropdown.ReactModal__Content--after-open', {
-  opacity: 1,
-  transition: 'opacity 150ms',
-})
-
-css.global('.dropdown.ReactModal__Content--before-close', {
-  opacity: 0,
-})
-
-export const overlayStyles = css({
-  backgroundColor: 'transparent',
-  position: 'fixed',
-  top: 0, left: 0, right: 0, bottom: 0,
-})
-
-export const StyledWrapper = glamorous(ReactModal)({
+export const StyledWrapper = glamorous(Popover)({
   maxWidth: '300px',
   minWidth: '160px',
   backgroundColor: theme.colors.white,
   borderRadius: theme.radius*2,
   padding: theme.space[1],
   boxShadow: '0 0 0 2px rgba(0,0,0,0.1)',
-  position: 'relative',
-  top: '50%',
-  left: '50%',
   transform: 'translateX(-50%)',
   '&:focus': {
     outline: 'none',

--- a/src/components/EntityCard/index.js
+++ b/src/components/EntityCard/index.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import T from 'prop-types'
-import { StyledFlex, StyledBox, StyledHeading } from './styled'
+import { StyledCard, StyledBox, StyledHeading } from './styled'
 import Text from '../Text'
 import Avatar from '../Avatar'
 
@@ -8,13 +8,13 @@ class EntityCard extends PureComponent {
   render () {
     const {name, description, avatar} = this.props
     return (
-      <StyledFlex p={'24px'}>
+      <StyledCard p={'24px'}>
         {avatar && <Avatar mr={2} src={avatar} /> }
         <StyledBox>
           <StyledHeading mb={1} mt={'2px'}>{name}</StyledHeading>
           {description && <Text muted small>{description}</Text>}
         </StyledBox>
-      </StyledFlex>
+      </StyledCard>
     )
   }
 }

--- a/src/components/EntityCard/styled.js
+++ b/src/components/EntityCard/styled.js
@@ -1,20 +1,12 @@
 import glamorous from 'glamorous'
-import theme from '../../styles/theme'
 import { fontSize, ellipsis } from '../../styles/mixins'
 import Heading from '../Heading'
-import { Flex, Box } from '../Grid'
-import { colors } from '../../styles/colors'
+import Card from '../Card'
+import { Box } from '../Grid'
 
-export const StyledFlex = glamorous(Flex)({
+export const StyledCard = glamorous(Card)({
   alignItems: 'center',
-  backgroundColor: theme.colors.white,
-  borderRadius: theme.radius*2,
-  transition: 'box-shadow .2s',
-  color: colors.text,
-  width: '100%',
-  '&:hover': {
-    boxShadow: '0 2px 6px 0 rgba(0,0,0,.2)',
-  }
+  display: 'flex',
 })
 
 export const StyledBox = glamorous(Box)({

--- a/src/components/Grid/index.js
+++ b/src/components/Grid/index.js
@@ -7,8 +7,11 @@ import {
   StyledFlex,
 } from './styled'
 
-export const Box = props =>
-  <StyledBox {...props}>{props.children}</StyledBox>
+export class Box extends Component {
+  render () {
+    return <StyledBox {...this.props} />
+  }
+}
 
 export const Flex = props =>
   <StyledFlex {...props}>{props.children}</StyledFlex>

--- a/src/components/Grid/styled.js
+++ b/src/components/Grid/styled.js
@@ -1,16 +1,18 @@
 import glamorous from 'glamorous'
 import withIsProp from '../../utils/withIsProp'
-import width from 'styled-system/dist/width'
-import space from 'styled-system/dist/space'
-import color from 'styled-system/dist/color'
-import borderWidth from 'styled-system/dist/border-width'
-import borderRadius from 'styled-system/dist/border-radius'
-import borderColor from 'styled-system/dist/border-color'
-import flexWrap from 'styled-system/dist/flex-wrap'
-import flexDirection from 'styled-system/dist/flex-direction'
-import alignSelf from 'styled-system/dist/align-self'
-import alignItems from 'styled-system/dist/align-items'
-import justifyContent from 'styled-system/dist/justify-content'
+import {
+  width,
+  space,
+  color,
+  borderWidth,
+  borderRadius,
+  borderColor,
+  flexWrap,
+  flexDirection,
+  alignSelf,
+  alignItems,
+  justifyContent
+} from 'styled-system'
 
 export const StyledBox = withIsProp(glamorous('div')(
   [{}],

--- a/src/components/Heading/styled.js
+++ b/src/components/Heading/styled.js
@@ -1,9 +1,6 @@
 import glamorous from 'glamorous'
 import withIsProp from '../../utils/withIsProp'
-import width from 'styled-system/dist/width'
-import space from 'styled-system/dist/space'
-import color from 'styled-system/dist/color'
-import textAlign from 'styled-system/dist/text-align'
+import { width, space, color, textAlign } from 'styled-system'
 
 export const StyledHeading = withIsProp(glamorous('h1')(
   [{

--- a/src/components/Number/README.md
+++ b/src/components/Number/README.md
@@ -44,5 +44,23 @@ Since percentages are used widely, they have their own dedicated component. For 
 ```
 
 ```react|span-3
+<Percentage size="large" value={25} />
+```
+
+```react|span-3
 <Number sup="℃" size="large" value={25} description="Degress" />
+```
+
+## Colored `Percentage`
+
+```react|span-3
+<Percentage colored size="large" value={98.2} />
+```
+
+```react|span-3
+<Percentage colored size="large" value={74.2} />
+```
+
+```react|span-3
+<Percentage colored size="large" value={51.9} />
 ```

--- a/src/components/Number/index.js
+++ b/src/components/Number/index.js
@@ -5,18 +5,18 @@ const StyledSpan = Dt.withComponent('span')
 
 class NumberComponent extends Component {
   render () {
-    const {size, suffix, value, description} = this.props
+    const {size, prefix, suffix, value, description} = this.props
 
     if (description) {
       return (
         <Dl size={size}>
-          <Dt size={size}>{value}{suffix && <Suffix>{suffix}</Suffix>}</Dt>
+          <Dt size={size}>{prefix && prefix}{value}{suffix && <Suffix>{suffix}</Suffix>}</Dt>
           <Dd size={size}>{description}</Dd>
         </Dl>
       )
     } else {
       return (
-        <StyledSpan size={size}>{value}{suffix && <Suffix>{suffix}</Suffix>}</StyledSpan>
+        <StyledSpan size={size}>{prefix && prefix}{value}{suffix && <Suffix>{suffix}</Suffix>}</StyledSpan>
       )
     }
 

--- a/src/components/Number/styled.js
+++ b/src/components/Number/styled.js
@@ -7,6 +7,7 @@ import styleIf from '../../utils/styleIf'
 
 const isSmall = ({ size }) => size === 'small'
 const isLarge = ({ size }) => size === 'large'
+const isDisplay = ({ size }) => size === 'display'
 
 export const Dl = glamorous.dl({
   fontVariantNumeric: 'tabular-nums',
@@ -16,15 +17,19 @@ export const Dl = glamorous.dl({
 export const Dt = glamorous.dt(
   {
     ...font('bold'),
-    ...fontSize('large'),
+    ...fontSize('medium'),
     letterSpacing: '-0.03em',
   },
+  styleIf(isDisplay, {
+    ...fontSize('xxlarge'),
+    marginLeft: '-2px',
+  }),
   styleIf(isLarge, {
-    ...fontSize('xlarge'),
+    ...fontSize('large'),
     marginLeft: '-2px',
   }),
   styleIf(isSmall, {
-    ...fontSize('xsmall'),
+    ...fontSize('small'),
   })
 )
 

--- a/src/components/Percentage/index.js
+++ b/src/components/Percentage/index.js
@@ -1,6 +1,9 @@
-import withProps from 'recompose/withProps'
+import { StyledWrapper } from './styled'
 import NumberComponent from '../Number'
 
-export default withProps(props => ({
-  suffix: '%',
-}))(NumberComponent)
+const Percentage = props =>
+  <StyledWrapper colored={props.colored} value={props.value}>
+    <NumberComponent {...props} suffix='%' />
+  </StyledWrapper>
+
+export default Percentage

--- a/src/components/Percentage/styled.js
+++ b/src/components/Percentage/styled.js
@@ -1,0 +1,29 @@
+import glamorous from 'glamorous'
+import { completionGradient } from '../../styles/mixins'
+import { getPercentage } from '../../utils/calculations'
+import theme from '../../styles/theme'
+
+export const StyledWrapper = glamorous('div')({
+  display: 'inline-block',
+}, props => {
+  if (props.colored === 'gradient') {
+    return {
+      ...completionGradient('dark'),
+      backgroundPosition: `${getPercentage(props.value, 100)}% center`,
+      color: 'transparent',
+      backgroundClip: 'text',
+      '-webkit-background-clip': 'text',
+      TextFillColor: 'transparent',
+      '-webkit-text-fill-color': 'transparent',
+    }
+  } else if (props.colored === true) {
+    if (props.value > 0) {
+      return {
+        color: theme.colors.goodDark,
+      }
+    }
+    return {
+      color: theme.colors.troubleDark,
+    }
+  }
+})

--- a/src/components/Report/README.md
+++ b/src/components/Report/README.md
@@ -1,7 +1,83 @@
+To make every card on the same line have equal height, simply wrap them in `Flex`.
+
 ```react
-<Report
-  heading="Tablet"
-  type="Preset"
-  value="25"
-  description="completion" />
+<Flex wrap>
+  <Flex w={[1, 1/2, 1/3]} p={2}>
+    <ReportCard
+      heading="Desktop"
+      byline="91 312 responses"
+      source="demobank.com"
+      type="Report"
+      value='85.1'
+    />
+  </Flex>
+  <Flex w={[1, 1/2, 1/3]} p={2}>
+    <ComparisonCard
+      heading="Comparison name"
+      source="iOS App"
+      type="Comparison"
+      values={[
+        45.2,
+        51.2,
+      ]}
+    />
+  </Flex>
+  <Flex w={[1, 1/2, 1/3]} p={2}>
+    <ComparisonCard
+      heading="Comparison name"
+      source="demobank.com"
+      type="Comparison"
+      values={[
+        45.2,
+        51.2,
+        72.4,
+      ]}
+    />
+  </Flex>
+</Flex>
+```
+
+```react|span-3
+<ReportCard
+  heading="Desktop"
+  byline="91 312 responses"
+  source="demobank.com"
+  type="Report"
+  value='45.2'
+/>
+```
+
+```react|span-3
+<ReportCard
+  heading="Desktop"
+  byline="91 312 responses"
+  source="demobank.com"
+  type="Report"
+  value='85.1'
+/>
+```
+
+```react|span-3
+<ComparisonCard
+  heading="Desktop"
+  source="iOS App"
+  type="Comparison"
+  values={[
+    85.2,
+    79.4,
+  ]}
+/>
+```
+
+```react|span-3
+<ComparisonCard
+  heading="Desktop"
+  source="demobank.com"
+  type="Comparison"
+  values={[
+    45.2,
+    51.2,
+    72.4,
+  ]}
+/>
 ```

--- a/src/components/Report/catalog.js
+++ b/src/components/Report/catalog.js
@@ -1,8 +1,11 @@
-import Report from '.'
+import { ReportCard, ComparisonCard } from '.'
+import Percentage from '../Percentage'
+import Card from '../Card'
+import {Flex} from '../Grid'
 
 export default {
   title: 'Report',
   path: '/components/report',
-  imports: { Report },
+  imports: { Card, Percentage, ReportCard, ComparisonCard, Flex },
   component: require('./README.md'),
 }

--- a/src/components/Report/index.js
+++ b/src/components/Report/index.js
@@ -1,30 +1,104 @@
 import React, { Component } from 'react'
 import T from 'prop-types'
-import { StyledBox, StyledHeading, StyledText } from './styled'
 import Text from '../Text'
+import {Box} from '../Grid'
 import Percentage from '../Percentage'
+import { getDelta } from '../../utils/calculations'
 
-class ReportComponent extends Component {
+import {
+  StyledCard,
+  StyledHeading,
+  StyledByline,
+  StyledSource,
+  StyledValue
+} from './styled'
+
+export class ReportCard extends Component {
   render () {
-    const {heading, type, value, description} = this.props
+    const {
+      heading,
+      value,
+      byline,
+      source,
+      type,
+    } = this.props
 
     return (
-      <StyledBox p={2}>
-        <StyledHeading is="h2" mb={0}>{heading}</StyledHeading>
-        <Text small muted mb={2}>{type}</Text>
-        <Percentage size="medium" value={value} description={description} />
-      </StyledBox>
+      <StyledCard>
+        <StyledHeading>{heading}</StyledHeading>
+        <Percentage colored='gradient' size='display' value={value} />
+        <StyledByline>{byline}</StyledByline>
+        <StyledSource>
+          <strong>{source}</strong>
+          {type && ' ' + type}
+        </StyledSource>
+      </StyledCard>
     )
   }
+
 }
 
-if (process.env.NODE_ENV !== 'production') {
-  ReportComponent.propTypes = {
-    heading: T.string.isRequired,
-    type: T.string.isRequired,
-    value: T.number.isRequired,
-    description: T.string,
+const Delta = ({ base, diff, size }) => {
+  const delta = getDelta(base, diff)
+  let prefix
+  if (delta > 0) {
+    prefix = '+'
   }
+  return (
+    <Percentage
+      colored
+      prefix={prefix}
+      suffix='%'
+      size={size}
+      value={delta}
+    />
+  )
 }
 
-export default ReportComponent
+const Values = ({ values }) => {
+  return (
+    values.map((value, i, values) =>
+      <span>
+        <Percentage colored='gradient' key={value.key} value={value} />
+        {values.length - 1 === i
+          ? null
+          : <Text muted mx='0.3em'>vs</Text>}
+      </span>
+    )
+  )
+}
+
+export class ComparisonCard extends Component {
+
+  render () {
+    const {
+      heading,
+      values,
+      source,
+      type,
+    } = this.props
+
+    return (
+      <StyledCard>
+        <StyledHeading>{heading}</StyledHeading>
+        {values.length > 2
+        ? <Values values={values} />
+        : <span>
+            <Delta
+              base={values[0]}
+              diff={values[1]}
+              size='display' />
+            <StyledByline>
+              {values[0]}% vs {values[1]}%
+            </StyledByline>
+          </span>
+        }
+        <StyledSource>
+          <strong>{source}</strong>
+          {type && ' ' + type}
+        </StyledSource>
+      </StyledCard>
+    )
+  }
+
+}

--- a/src/components/Report/styled.js
+++ b/src/components/Report/styled.js
@@ -3,21 +3,17 @@ import glamorous from 'glamorous'
 import * as spacing from '../../styles/spacing'
 import theme from '../../styles/theme'
 import {font, fontSize} from '../../styles/mixins'
-import {colors} from '../../styles/colors'
 
 import {Box} from '../Grid'
 import Heading from '../Heading'
 import Text from '../Text'
+import Card from '../Card'
 
-export const StyledBox = glamorous(Box)({
-  alignItems: 'center',
-  backgroundColor: colors.white,
-  borderRadius: theme.radius*2,
-  transition: 'box-shadow .2s',
-  color: colors.text,
-  '&:hover': {
-    boxShadow: '0 2px 6px 0 rgba(0,0,0,.1)',
-  },
+const pad = theme.space[4]
+
+export const StyledCard = glamorous(Card)({
+  padding: pad,
+  paddingBottom: pad*2.5,
 })
 
 export const StyledHeading = glamorous(Heading)({
@@ -25,7 +21,19 @@ export const StyledHeading = glamorous(Heading)({
   ...fontSize('small'),
 })
 
-export const StyledText = glamorous(Text)({
-  marginBottom: spacing.base,
-  color: colors.muted,
+export const StyledByline = glamorous(Text)({
+  display: 'block',
+  color: theme.colors.muted,
+})
+
+export const StyledSource = glamorous(Text)({
+  display: 'block',
+  position: 'absolute',
+  bottom: pad,
+  ...fontSize('xxsmall'),
+  color: theme.colors.muted,
+})
+
+export const StyledValue = glamorous(Box)({
+  display: 'block',
 })

--- a/src/components/Text/styled.js
+++ b/src/components/Text/styled.js
@@ -1,8 +1,5 @@
 import glamorous from 'glamorous'
-import width from 'styled-system/dist/width'
-import space from 'styled-system/dist/space'
-import color from 'styled-system/dist/color'
-import textAlign from 'styled-system/dist/text-align'
+import { width, space, color, textAlign } from 'styled-system'
 
 import withIsProp from '../../utils/withIsProp'
 import styleIf from '../../utils/styleIf'

--- a/src/styles/mixins.js
+++ b/src/styles/mixins.js
@@ -12,18 +12,27 @@ export const ellipsis = () => ({
   textOverflow: 'ellipsis',
 })
 
-export const completionGradient = () => ({
-  backgroundImage: `
-    linear-gradient(
-      to right,
-      ${theme.colors.trouble} 55%,
-      ${theme.colors.headsUp},
-      ${theme.colors.headsUp} 80%,
-      ${theme.colors.good} 90%,
-      ${theme.colors.good})
-  `,
-  backgroundSize: '2100%',
-})
+export const completionGradient = (dark) => {
+  var colorGood = theme.colors.good
+  if (dark) {
+    colorGood = theme.colors.goodDark
+  }
+  const colorHeadsUp = theme.colors.headsUp
+  const colorTrouble = theme.colors.trouble
+
+  return {
+    backgroundImage: `
+      linear-gradient(
+        to right,
+        ${colorTrouble} 55%,
+        ${colorHeadsUp},
+        ${colorHeadsUp} 80%,
+        ${colorGood} 90%,
+        ${colorGood})
+    `,
+    backgroundSize: '2100%',
+  }
+}
 
 const textWeights = {
   light: 300,
@@ -52,8 +61,8 @@ const fontSizes = {
   small: { base: ['19px', 1.3] },
   medium: { base: ['22px', 1.6] },
   large: { base: ['26px', 1.1] },
-  xlarge: { base: '30px', md: '32px', lg: '40px' },
-  xxlarge: { base: '30px', md: '38px', lg: '44px' },
+  xlarge: { base: ['30px', 1.2], md: '32px', lg: '40px' },
+  xxlarge: { base: ['30px', 1.2], md: '38px', lg: '44px' },
 }
 
 const fontSizeRule = fontSize => {

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -19,8 +19,11 @@ const theme = {
     muted: 'rgba(45, 54, 68, 0.6)',
     primary: '#2084d8',
     good: rgba(140, 215, 150, 1),
+    goodDark: '#3BBE77',
     headsUp: rgba(255, 212, 0, 1),
+    headsUpDark: '#FFA707',
     trouble: rgba(255, 90, 20, 1),
+    troubleDark: '#FF5915',
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2944,7 +2944,7 @@ dom-helpers@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
-dom-helpers@^3.2.0:
+dom-helpers@^3.2.0, dom-helpers@^3.2.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
@@ -7235,6 +7235,12 @@ prop-types-exact@1.1.1:
     has "^1.0.1"
     object.assign "^4.0.4"
 
+prop-types-extra@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prop-types-extra/-/prop-types-extra-1.0.1.tgz#a57bd4810e82d27a3ff4317ecc1b4ad005f79a82"
+  dependencies:
+    warning "^3.0.0"
+
 prop-types@15.6.0, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
@@ -7452,6 +7458,15 @@ react-document-title@^2.0.3:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-dom@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 react-error-overlay@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-2.0.2.tgz#967b091962b17f5aeb4a60b1311b1736e1b6533d"
@@ -7490,6 +7505,17 @@ react-modal@^3.1.10:
     prop-types "^15.5.10"
     warning "^3.0.0"
 
+react-overlays@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.8.3.tgz#fad65eea5b24301cca192a169f5dddb0b20d3ac5"
+  dependencies:
+    classnames "^2.2.5"
+    dom-helpers "^3.2.1"
+    prop-types "^15.5.10"
+    prop-types-extra "^1.0.1"
+    react-transition-group "^2.2.0"
+    warning "^3.0.0"
+
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz#4400426bcfa80caa6724c7755695315209fa4b07"
@@ -7523,7 +7549,16 @@ react-side-effect@^1.0.2:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
-react-transition-group@^2.2.1:
+react-simple-popover@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/react-simple-popover/-/react-simple-popover-0.2.4.tgz#16ce1051a92ce9e1810f1713440c21c8fe1d42ce"
+  dependencies:
+    prop-types "^15.6.0"
+    react "^16.2.0"
+    react-dom "^16.2.0"
+    react-overlays "^0.8.3"
+
+react-transition-group@^2.2.0, react-transition-group@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.2.1.tgz#e9fb677b79e6455fd391b03823afe84849df4a10"
   dependencies:
@@ -7537,6 +7572,15 @@ react-transition-group@^2.2.1:
 "react@^15 || ^16", react@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -8828,9 +8872,9 @@ styled-jsx@2.0.2:
     string-hash "1.1.1"
     stylis "3.2.18"
 
-styled-system@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-1.1.1.tgz#6611da9ce5e561b50f217996ea555ea7b1855d5d"
+styled-system@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-2.1.1.tgz#ec7cd9c25f8413662c90a3ff1b6660cf8d744163"
   dependencies:
     prop-types "^15.6.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -262,14 +262,14 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-args@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/args/-/args-3.0.4.tgz#8f98de16f14547e061ba8ccec82d7f660195c583"
+args@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/args/-/args-3.0.8.tgz#2f425ab639c69d74ff728f3d7c6e93b97b91af7c"
   dependencies:
     camelcase "4.1.0"
-    chalk "2.0.1"
-    minimist "1.2.0"
-    pkginfo "0.4.0"
+    chalk "2.1.0"
+    mri "1.1.0"
+    pkginfo "0.4.1"
     string-similarity "1.2.0"
 
 argx@^3.0.0:
@@ -1860,11 +1860,11 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-catalog@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/catalog/-/catalog-3.1.2.tgz#24ffa8b23236ac5fd1998ac1d811fdd06283a965"
+catalog@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/catalog/-/catalog-3.4.0.tgz#6e48e310bfd90ed32069b4770deeeea2a6eb7b4a"
   dependencies:
-    args "^3.0.4"
+    args "^3.0.8"
     autoprefixer "^7.1.3"
     babel-core "^6.26.0"
     babel-loader "^7.1.2"
@@ -1888,7 +1888,7 @@ catalog@^3.1.2:
     history "^3.2.1"
     html-webpack-plugin "^2.30.1"
     js-yaml "^3.9.1"
-    marked "^0.3.2"
+    marked "^0.3.12"
     postcss-loader "^2.0.6"
     prismjs "^1.3.0"
     prop-types "^15.6.0"
@@ -1930,14 +1930,6 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
-
-chalk@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
-  dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
 
 chalk@2.1.0, chalk@^2.0.0, chalk@^2.1.0:
   version "2.1.0"
@@ -2944,7 +2936,7 @@ dom-helpers@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
-dom-helpers@^3.2.0, dom-helpers@^3.2.1:
+dom-helpers@^3.2.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
@@ -4047,7 +4039,7 @@ git-semver-tags@^1.2.2:
     meow "^3.3.0"
     semver "^5.0.1"
 
-"gitconfig@github:teambit/node-gitconfig":
+gitconfig@teambit/node-gitconfig:
   version "2.0.4"
   resolved "https://codeload.github.com/teambit/node-gitconfig/tar.gz/80292a3a2b837b27fffefaff71fe1fa13ecca6ea"
   dependencies:
@@ -5705,9 +5697,9 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-marked@^0.3.2:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
+marked@^0.3.12:
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.18.tgz#3ef058cd926101849b92a7a7c15db18c7fc76b2f"
 
 math-clamp-x@^1.2.0:
   version "1.2.0"
@@ -5963,6 +5955,10 @@ morgan@^1.5.0:
     depd "~1.1.0"
     on-finished "~2.3.0"
     on-headers "~1.0.1"
+
+mri@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.0.tgz#5c0a3f29c8ccffbbb1ec941dcec09d71fa32f36a"
 
 ms@2.0.0:
   version "2.0.0"
@@ -6800,11 +6796,7 @@ pkginfo@0.3.x:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
 
-pkginfo@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.0.tgz#349dbb7ffd38081fcadc0853df687f0c7744cd65"
-
-pkginfo@0.x.x:
+pkginfo@0.4.1, pkginfo@0.x.x:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
 
@@ -7235,12 +7227,6 @@ prop-types-exact@1.1.1:
     has "^1.0.1"
     object.assign "^4.0.4"
 
-prop-types-extra@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/prop-types-extra/-/prop-types-extra-1.0.1.tgz#a57bd4810e82d27a3ff4317ecc1b4ad005f79a82"
-  dependencies:
-    warning "^3.0.0"
-
 prop-types@15.6.0, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
@@ -7458,15 +7444,6 @@ react-document-title@^2.0.3:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-dom@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 react-error-overlay@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-2.0.2.tgz#967b091962b17f5aeb4a60b1311b1736e1b6533d"
@@ -7505,17 +7482,6 @@ react-modal@^3.1.10:
     prop-types "^15.5.10"
     warning "^3.0.0"
 
-react-overlays@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.8.3.tgz#fad65eea5b24301cca192a169f5dddb0b20d3ac5"
-  dependencies:
-    classnames "^2.2.5"
-    dom-helpers "^3.2.1"
-    prop-types "^15.5.10"
-    prop-types-extra "^1.0.1"
-    react-transition-group "^2.2.0"
-    warning "^3.0.0"
-
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz#4400426bcfa80caa6724c7755695315209fa4b07"
@@ -7549,16 +7515,7 @@ react-side-effect@^1.0.2:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
-react-simple-popover@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/react-simple-popover/-/react-simple-popover-0.2.4.tgz#16ce1051a92ce9e1810f1713440c21c8fe1d42ce"
-  dependencies:
-    prop-types "^15.6.0"
-    react "^16.2.0"
-    react-dom "^16.2.0"
-    react-overlays "^0.8.3"
-
-react-transition-group@^2.2.0, react-transition-group@^2.2.1:
+react-transition-group@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.2.1.tgz#e9fb677b79e6455fd391b03823afe84849df4a10"
   dependencies:
@@ -7572,15 +7529,6 @@ react-transition-group@^2.2.0, react-transition-group@^2.2.1:
 "react@^15 || ^16", react@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
-react@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,10 +1917,6 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chain-function@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
-
 chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1946,10 +1942,6 @@ chalk@^2.0.1, chalk@^2.3.0, chalk@^2.3.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-change-emitter@^0.1.2:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
 
 char-spinner@^1.0.1:
   version "1.0.1"
@@ -1986,10 +1978,6 @@ clap@^1.0.9:
   resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.3.tgz#4f36745b32008492557f46412d66d50cb99bce51"
   dependencies:
     chalk "^1.1.3"
-
-classnames@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
 clean-css@4.1.x:
   version "4.1.9"
@@ -2936,10 +2924,6 @@ dom-helpers@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
-dom-helpers@^3.2.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
-
 dom-serializer@0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
@@ -3613,9 +3597,9 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.1, fbjs@^0.8.9:
-  version "0.8.12"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+fbjs@^0.8.12, fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -3625,9 +3609,9 @@ fbjs@^0.8.1, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fbjs@^0.8.12, fbjs@^0.8.16:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -4431,7 +4415,7 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
-hoist-non-react-statics@2.3.1, hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.3.1:
+hoist-non-react-statics@2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
@@ -7395,12 +7379,6 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-click-outside@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-click-outside/-/react-click-outside-3.0.0.tgz#7a69a90d31b99204ef5d509cae91f52460d6fd69"
-  dependencies:
-    hoist-non-react-statics "^2.1.1"
-
 react-deep-force-update@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz#8ea4263cd6455a050b37445b3f08fd839d86e909"
@@ -7515,17 +7493,6 @@ react-side-effect@^1.0.2:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
-react-transition-group@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.2.1.tgz#e9fb677b79e6455fd391b03823afe84849df4a10"
-  dependencies:
-    chain-function "^1.0.0"
-    classnames "^2.2.5"
-    dom-helpers "^3.2.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.5.8"
-    warning "^3.0.0"
-
 "react@^15 || ^16", react@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
@@ -7630,15 +7597,6 @@ readdirp@^2.0.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
-
-recompose@^0.25.1:
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.25.1.tgz#5eb9d6cf6e25a9ffad73cbbae5658b5b55d6e728"
-  dependencies:
-    change-emitter "^0.1.2"
-    fbjs "^0.8.1"
-    hoist-non-react-statics "^2.3.1"
-    symbol-observable "^1.0.4"
 
 recursive-copy@2.0.6:
   version "2.0.6"
@@ -8910,10 +8868,6 @@ svgo@^0.7.0:
     mkdirp "~0.5.1"
     sax "~1.2.1"
     whet.extend "~0.9.9"
-
-symbol-observable@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 symlink-or-copy@^1.1.8:
   version "1.2.0"


### PR DESCRIPTION
This adds a `<Card>` component and changes `<ReportCard>` and `<CompletionCard>` to build on top of the primitive card.
It also refactors `<Dropdown>` to build natively around a `<dialog>` element instead of using a library.

Fixes #35, #18 